### PR TITLE
Fixed toolchain_clang_fpgav3.cmake.in to force linking to all important sysroot headers

### DIFF
--- a/cmake/toolchain_clang_fpgav3.cmake.in
+++ b/cmake/toolchain_clang_fpgav3.cmake.in
@@ -46,6 +46,16 @@ endif ()
 
 find_program (CLANG_CC "clang${CLANG_SUFFIX}" REQUIRED)
 
+# Extract clang version if not provided
+if (NOT CLANG_VERSION)
+  execute_process(
+    COMMAND ${CLANG_CC} --version
+    OUTPUT_VARIABLE CLANG_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "version ([0-9]+)" _ "${CLANG_VERSION_OUTPUT}")
+  set(CLANG_VERSION "${CMAKE_MATCH_1}")
+endif()
+
 # Derive clang include path from clang installation
 get_filename_component (CLANG_BIN_DIR "${CLANG_CC}" DIRECTORY)
 get_filename_component (CLANG_INSTALL_DIR "${CLANG_BIN_DIR}" DIRECTORY)

--- a/cmake/toolchain_clang_fpgav3.cmake.in
+++ b/cmake/toolchain_clang_fpgav3.cmake.in
@@ -87,7 +87,8 @@ include_directories ("${Sysroot}/usr/include/c++/${gccVer}/${sysrootPath}"
 # Following compiler definition required for floating point hardware
 add_definitions(-D__ARM_PCS_VFP)
 
-set (EXTRA_COMPILER_FLAGS "-mfloat-abi=hard --target=${gnuArch}")
+set (EXTRA_COMPILER_FLAGS "-mfloat-abi=hard --target=${gnuArch} -Wno-error=deprecated-declarations")
+set (EXTRA_CXX_FLAGS "-std=c++14")
 
 set (EXTRA_LINKER_FLAGS
      "-Wl,-z,notext -fuse-ld=${CLANG_LINKER} -B${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer} -L${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer}")
@@ -100,7 +101,7 @@ set (EXTRA_LINKER_FLAGS
 # because this code seems to be run twice and we end up with duplication.
 
 set (CMAKE_C_FLAGS   "${EXTRA_COMPILER_FLAGS}" CACHE STRING "" FORCE)
-set (CMAKE_CXX_FLAGS "${EXTRA_COMPILER_FLAGS}" CACHE STRING "" FORCE)
+set (CMAKE_CXX_FLAGS "${EXTRA_COMPILER_FLAGS} ${EXTRA_CXX_FLAGS}" CACHE STRING "" FORCE)
 set (CMAKE_ASM_FLAGS "${EXTRA_COMPILER_FLAGS}" CACHE STRING "" FORCE)
 
 set (CMAKE_SHARED_LINKER_FLAGS "${EXTRA_LINKER_FLAGS}" CACHE STRING "" FORCE)

--- a/cmake/toolchain_clang_fpgav3.cmake.in
+++ b/cmake/toolchain_clang_fpgav3.cmake.in
@@ -46,6 +46,11 @@ endif ()
 
 find_program (CLANG_CC "clang${CLANG_SUFFIX}" REQUIRED)
 
+# Derive clang include path from clang installation
+get_filename_component (CLANG_BIN_DIR "${CLANG_CC}" DIRECTORY)
+get_filename_component (CLANG_INSTALL_DIR "${CLANG_BIN_DIR}" DIRECTORY)
+set (CLANG_INCLUDE_DIR "${CLANG_INSTALL_DIR}/lib/clang/${CLANG_VERSION}/include")
+
 set (CMAKE_C_COMPILER          "clang${CLANG_SUFFIX}")
 set (CMAKE_C_COMPILER_TARGET   ${gnuArch})
 set (CMAKE_CXX_COMPILER        "clang++${CLANG_SUFFIX}")
@@ -87,11 +92,18 @@ include_directories ("${Sysroot}/usr/include/c++/${gccVer}/${sysrootPath}"
 # Following compiler definition required for floating point hardware
 add_definitions(-D__ARM_PCS_VFP)
 
-set (EXTRA_COMPILER_FLAGS "-mfloat-abi=hard --target=${gnuArch} -Wno-error=deprecated-declarations")
+set (EXTRA_COMPILER_FLAGS
+     "-mfloat-abi=hard -mfpu=neon --target=${gnuArch} --sysroot=${Sysroot} \
+      -nostdinc \
+      -isystem ${Sysroot}/usr/include/c++/${gccVer} \
+      -isystem ${Sysroot}/usr/include/c++/${gccVer}/${sysrootPath} \
+      -isystem ${Sysroot}/usr/include/c++/${gccVer}/${sysrootPathHf} \
+      -isystem ${CLANG_INCLUDE_DIR} \
+      -isystem ${Sysroot}/usr/include")
 set (EXTRA_CXX_FLAGS "-std=c++14")
 
 set (EXTRA_LINKER_FLAGS
-     "-Wl,-z,notext -fuse-ld=${CLANG_LINKER} -B${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer} -L${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer}")
+     "-Wl,-z,notext -fuse-ld=${CLANG_LINKER} -B${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer} -L${Sysroot}/usr/lib/${sysrootPathHf}/${gccVer} -L${Sysroot}/usr/lib -L${Sysroot}/lib --sysroot=${Sysroot}")
 
 ##################################################################
 # Set CMake compiler and linker flags


### PR DESCRIPTION
I forced the toolchain file to link to all the important c++ directories. Initially it was defaulting to look for these directories on the host machine which created many header version conflicts. 

Added these extra compile flags: 

set (EXTRA_COMPILER_FLAGS
     "-mfloat-abi=hard -mfpu=neon --target=${gnuArch} --sysroot=${Sysroot} \
      -nostdinc \
      -isystem ${Sysroot}/usr/include/c++/${gccVer} \
      -isystem ${Sysroot}/usr/include/c++/${gccVer}/${sysrootPath} \
      -isystem ${Sysroot}/usr/include/c++/${gccVer}/${sysrootPathHf} \
      -isystem ${CLANG_INCLUDE_DIR} \
      -isystem ${Sysroot}/usr/include")
      
I also set the c++ version to 14 since it seems to be the most stable on this zynq arm processor. 


****NOTE****
Mechatronics embedded fails to fully build because a tag is not set in my repo. I didn't want to mess up the tag regime that is already in place.